### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/README.org
+++ b/README.org
@@ -40,7 +40,7 @@ The main quirk is that the system has to force automatic saving of the edited Ha
   #+end_src
 -  *Without [[https://melpa.org/][MELPA]] (manual installation):*
   - First install the following packages which are required as dependencies:
-    - ~company~, ~helm~, ~async~, ~dash~, ~dash-functional~, ~f~, ~s~, and optionally, ~yasnippet~.
+    - ~company~, ~helm~, ~async~, ~dash~, ~f~, ~s~, and optionally, ~yasnippet~.
   - Git-clone this package and add it to your load path, for example:
     #+begin_src elisp
     ;; Tell Emacs where your elisp library sits

--- a/battle-haxe.el
+++ b/battle-haxe.el
@@ -5,7 +5,7 @@
 ;; Author: Alon Tzarafi  <alontzarafi@gmail.com>
 ;; URL: https://github.com/AlonTzarafi/battle-haxe
 ;; Version: 1.0
-;; Package-Requires: ((emacs "25") (company "0.9.9") (helm "3.0") (async "1.9.3") (cl-lib "0.5") (dash "2.12.0") (dash-functional "1.2.0") (s "1.10.0") (f "0.19.0"))
+;; Package-Requires: ((emacs "25") (company "0.9.9") (helm "3.0") (async "1.9.3") (cl-lib "0.5") (dash "2.18.0") (s "1.10.0") (f "0.19.0"))
 ;; Keywords: programming, languages, completion
 
 ;; battle-haxe is free software; you can redistribute it and/or modify it
@@ -48,7 +48,6 @@
 (require 'xml)
 ;; -- (downloaded)
 (require 'dash)
-(require 'dash-functional)
 (require 's)
 (require 'f)
 
@@ -274,7 +273,7 @@ If a cache is valid, return it right away, else return async candidates."
   (let ((process-result
          (lambda (xml-str)
            ;; When it will get server results:
-           (-filter (-not #'string-empty-p)
+           (-remove #'string-empty-p
                     (battle-haxe-parse-completions-from-xml xml-str inserted-text))))
         (use-cached (alist-get 'approved battle-haxe-cached-completion-context)))
     (if use-cached


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`; see https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218.

Also simplify `battle-haxe-company-candidates` to not require any `dash-functional` definitions, although they're still available.