### PR TITLE
define the target

### DIFF
--- a/README.org
+++ b/README.org
@@ -78,6 +78,7 @@ but here is a template "some-project.hxml" to get you started for this use case:
 -cp src
 -lib lime
 -lib openfl
+-js example.js
 #+end_src
 
 * Notes


### PR DESCRIPTION
I had to add this in my .hxml project file to make it work with flixel, because I had an error with haxe 4.2.5 stating that : 

```txt
Could not find definition. Haxe returned this:
/usr/local/lib/haxe/std/sys/thread/Deque.hx:26: characters 8-52 : This class is not available on this target
```

As it was a game changer for me between a "working" and a "not working" state I propose to add it in the README.me so that other potential users use your beautiful library !